### PR TITLE
Fix: Optimize project data fetching to prevent timeouts

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -246,7 +246,7 @@ function getProjectData(projectId) {
     const project = parseProjectRow(data[1], projectId);
     if (project) {
       // Add slides data
-      project.slides = getSlidesByProject(projectId);
+      project.slides = getSlidesByProject(projectId, spreadsheet);
     }
     
     return project;
@@ -340,9 +340,11 @@ function duplicateProject(projectId) {
 /**
  * Get slides for a project
  */
-function getSlidesByProject(projectId) {
+function getSlidesByProject(projectId, spreadsheet = null) {
   try {
-    const spreadsheet = SpreadsheetApp.openById(projectId);
+    if (!spreadsheet) {
+      spreadsheet = SpreadsheetApp.openById(projectId);
+    }
     const slidesSheet = spreadsheet.getSheetByName('Slides');
     
     if (!slidesSheet) {


### PR DESCRIPTION
The project editing view was not loading for projects with many slides. This was due to a timeout in the `getProjectData` server-side function.

The `getProjectData` function was calling `getSlidesByProject`, which was unnecessarily re-opening the same Google Sheet that `getProjectData` had already opened. This redundant `SpreadsheetApp.openById()` call is a slow operation and was causing the script to time out.

This fix optimizes the data fetching by passing the already-opened spreadsheet object from `getProjectData` to `getSlidesByProject`. This avoids the redundant API call and resolves the timeout issue, allowing the project editor to load correctly.