### PR TITLE
Fix(project): Correctly open project by spreadsheetId

### DIFF
--- a/services/ProjectManager_server.js
+++ b/services/ProjectManager_server.js
@@ -40,11 +40,22 @@ class ProjectManager_server {
    * @param {string} projectId - Project ID
    * @returns {Object} Opened project
    */
-  openProject(projectId) {
+  async openProject(projectId) {
     const sheetsAPI = new GoogleSheetsAPI();
-    sheetsAPI.initialize(projectId);
-    const project = sheetsAPI.getProject(projectId);
-    project.slides = sheetsAPI.getSlidesByProject(projectId);
+
+    // Step 1: Initialize registry to get project spreadsheet ID
+    await sheetsAPI.initializeRegistry();
+    const projects = await sheetsAPI.getAllProjects();
+    const projectInfo = projects.find(p => p.id === projectId);
+
+    if (!projectInfo) {
+      throw new Error(`Project ${projectId} not found`);
+    }
+
+    // Step 2: Initialize with project spreadsheet and get project data
+    await sheetsAPI.initialize(projectInfo.spreadsheetId);
+    const project = await sheetsAPI.getProject(projectId);
+    project.slides = await sheetsAPI.getSlidesByProject(projectId);
     return project;
   }
   

--- a/tests/ProjectManager_server.test.js
+++ b/tests/ProjectManager_server.test.js
@@ -1,3 +1,81 @@
+// Mock GoogleSheetsAPI
+class MockGoogleSheetsAPI {
+  constructor() {
+    this.registryInitialized = false;
+    this.initialized = false;
+    this.spreadsheetId = null;
+    this.projects = {
+        'proj_1': {
+            id: 'proj_1',
+            name: 'Original Project',
+            description: 'Original Description',
+            settings: { setting1: 'value1' },
+            spreadsheetId: 'ssid_1'
+        }
+    };
+    this.slides = {
+        'ssid_1': [{ id: 'slide_1', projectId: 'proj_1', name: 'Slide 1' }]
+    };
+    this.hotspots = {
+        'slide_1': [{ id: 'hotspot_1', slideId: 'slide_1', name: 'Hotspot 1' }]
+    };
+  }
+  async initializeRegistry() { this.registryInitialized = true; return true; }
+  async getAllProjects() {
+    return Object.values(this.projects);
+  }
+  async initialize(spreadsheetId) {
+    this.initialized = true;
+    this.spreadsheetId = spreadsheetId;
+    return true;
+  }
+  async getProject(projectId) {
+    // In our mock, the project key is the projectId
+    const project = Object.values(this.projects).find(p => p.id === projectId && p.spreadsheetId === this.spreadsheetId);
+    return project || null;
+  }
+  async getSlidesByProject(projectId) {
+      const project = Object.values(this.projects).find(p => p.id === projectId);
+      if (project) {
+          return this.slides[project.spreadsheetId] || [];
+      }
+      return [];
+  }
+  async getHotspotsBySlide(slideId) {
+    return this.hotspots[slideId] || [];
+  }
+  async createProjectSpreadsheet(projectName) { return 'ssid_2'; }
+  async createProject(projectData) {
+      const newId = 'proj_' + Math.random().toString(36).substr(2, 9);
+      const newProject = { ...projectData, id: newId };
+      this.projects[newId] = newProject;
+      return newProject;
+  }
+  async createSlide(slideData) {
+      const newId = 'slide_' + Math.random().toString(36).substr(2, 9);
+      const newSlide = { ...slideData, id: newId };
+      if (!this.slides[this.spreadsheetId]) {
+          this.slides[this.spreadsheetId] = [];
+      }
+      this.slides[this.spreadsheetId].push(newSlide);
+      return newSlide;
+  }
+  async saveHotspots(hotspots) {
+      for (const hotspot of hotspots) {
+          if (!this.hotspots[hotspot.slideId]) {
+              this.hotspots[hotspot.slideId] = [];
+          }
+          this.hotspots[hotspot.slideId].push(hotspot);
+      }
+      return true;
+  }
+  async addProjectToRegistry(project) {
+      this.projects[project.id] = project;
+      return true;
+  }
+}
+
+
 /**
  * Test function for ProjectManager_server.duplicateProject
  * To run this test, you need to:
@@ -6,81 +84,6 @@
  * 3. Run this function from the Apps Script editor.
  */
 function test_duplicateProject() {
-  // Mock GoogleSheetsAPI
-  class MockGoogleSheetsAPI {
-    constructor() {
-      this.registryInitialized = false;
-      this.initialized = false;
-      this.spreadsheetId = null;
-      this.projects = {
-          'proj_1': {
-              id: 'proj_1',
-              name: 'Original Project',
-              description: 'Original Description',
-              settings: { setting1: 'value1' },
-              spreadsheetId: 'ssid_1'
-          }
-      };
-      this.slides = {
-          'ssid_1': [{ id: 'slide_1', projectId: 'proj_1', name: 'Slide 1' }]
-      };
-      this.hotspots = {
-          'slide_1': [{ id: 'hotspot_1', slideId: 'slide_1', name: 'Hotspot 1' }]
-      };
-    }
-    async initializeRegistry() { this.registryInitialized = true; return true; }
-    async getAllProjects() {
-      return Object.values(this.projects);
-    }
-    async initialize(spreadsheetId) {
-      this.initialized = true;
-      this.spreadsheetId = spreadsheetId;
-      return true;
-    }
-    async getProject(projectId) {
-      return this.projects[projectId] || null;
-    }
-    async getSlidesByProject(projectId) {
-        const project = this.projects[projectId];
-        if (project) {
-            return this.slides[project.spreadsheetId] || [];
-        }
-        return [];
-    }
-    async getHotspotsBySlide(slideId) {
-      return this.hotspots[slideId] || [];
-    }
-    async createProjectSpreadsheet(projectName) { return 'ssid_2'; }
-    async createProject(projectData) {
-        const newId = 'proj_' + Math.random().toString(36).substr(2, 9);
-        const newProject = { ...projectData, id: newId };
-        this.projects[newId] = newProject;
-        return newProject;
-    }
-    async createSlide(slideData) {
-        const newId = 'slide_' + Math.random().toString(36).substr(2, 9);
-        const newSlide = { ...slideData, id: newId };
-        if (!this.slides[this.spreadsheetId]) {
-            this.slides[this.spreadsheetId] = [];
-        }
-        this.slides[this.spreadsheetId].push(newSlide);
-        return newSlide;
-    }
-    async saveHotspots(hotspots) {
-        for (const hotspot of hotspots) {
-            if (!this.hotspots[hotspot.slideId]) {
-                this.hotspots[hotspot.slideId] = [];
-            }
-            this.hotspots[hotspot.slideId].push(hotspot);
-        }
-        return true;
-    }
-    async addProjectToRegistry(project) {
-        this.projects[project.id] = project;
-        return true;
-    }
-  }
-
   // Replace the real GoogleSheetsAPI with our mock
   GoogleSheetsAPI = MockGoogleSheetsAPI;
 
@@ -131,5 +134,42 @@ function test_duplicateProject() {
   }).finally(() => {
       // Restore original methods
       ProjectManager_server.prototype.createNewProject = originalCreateNewProject;
+  });
+}
+
+function test_openProject() {
+  // Replace the real GoogleSheetsAPI with our mock
+  GoogleSheetsAPI = MockGoogleSheetsAPI;
+
+  const projectManager = new ProjectManager_server();
+
+  console.log('Test started for openProject...');
+
+  projectManager.openProject('proj_1').then(p => {
+    console.log('Project opened:', JSON.stringify(p, null, 2));
+    let success = true;
+    if (p.id === 'proj_1' && p.name === 'Original Project') {
+      console.log('SUCCESS: Project data is correct.');
+    } else {
+      console.error('FAILURE: Project data is incorrect.');
+      success = false;
+    }
+
+    if (p.slides && p.slides.length === 1 && p.slides[0].id === 'slide_1') {
+      console.log('SUCCESS: Project slides are correct.');
+    } else {
+      console.error('FAILURE: Project slides are incorrect.');
+      success = false;
+    }
+
+    if (success) {
+        console.log('TEST PASSED');
+    } else {
+        console.log('TEST FAILED');
+    }
+
+  }).catch(e => {
+    console.error('FAILURE: An error occurred during opening project.', e);
+    console.log('TEST FAILED');
   });
 }


### PR DESCRIPTION
The `openProject` function was incorrectly using the `projectId` to initialize the `GoogleSheetsAPI`, which expects a `spreadsheetId`. This caused the function to fail when trying to open a project.

This commit fixes the `openProject` function by first retrieving the project's `spreadsheetId` from the master registry and then using that ID to initialize the `GoogleSheetsAPI`.

A new test case, `test_openProject`, has been added to `tests/ProjectManager_server.test.js` to verify the fix. The test mocks the necessary API calls and asserts that the project is opened correctly. The existing mock API in the test file was also refactored to be reusable by multiple test functions.