### PR TITLE
Fix: Ensure spreadsheetId is always added to new projects

### DIFF
--- a/services/GoogleSheetsAPI.js
+++ b/services/GoogleSheetsAPI.js
@@ -290,7 +290,8 @@ class GoogleSheetsAPI {
       ...projectData,
       id: this.generateId('proj'),
       createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString()
+      updatedAt: new Date().toISOString(),
+      spreadsheetId: this.options.spreadsheetId
     };
     
     await this.insertRow(SHEETS_CONFIG.PROJECTS_SHEET, this.projectToRow(project));

--- a/tests/ProjectManager_server.test.js
+++ b/tests/ProjectManager_server.test.js
@@ -137,6 +137,47 @@ function test_duplicateProject() {
   });
 }
 
+function test_createNewProject() {
+  // This test requires a more invasive mock to inspect the state of the sheetsAPI instance
+  // created within createNewProject. For this test, we'll check the return value,
+  // which is a strong indicator of success.
+
+  // Replace the real GoogleSheetsAPI with our mock
+  GoogleSheetsAPI = MockGoogleSheetsAPI;
+
+  const projectManager = new ProjectManager_server();
+
+  console.log('Test started for createNewProject...');
+
+  const newProjectData = {
+    name: 'Test Project',
+    description: 'A test project.'
+  };
+
+  projectManager.createNewProject(newProjectData).then(createdProject => {
+    console.log('Project created:', JSON.stringify(createdProject, null, 2));
+    let success = true;
+
+    // Assertion 1: Returned project has spreadsheetId
+    if (createdProject.spreadsheetId && createdProject.spreadsheetId === 'ssid_2') {
+      console.log('SUCCESS: Returned project has the correct spreadsheetId.');
+    } else {
+      console.error(`FAILURE: Returned project has incorrect or missing spreadsheetId. Expected 'ssid_2', got '${createdProject.spreadsheetId}'`);
+      success = false;
+    }
+
+    if (success) {
+        console.log('TEST PASSED');
+    } else {
+        console.log('TEST FAILED');
+    }
+
+  }).catch(e => {
+    console.error('FAILURE: An error occurred during project creation.', e);
+    console.log('TEST FAILED');
+  });
+}
+
 function test_openProject() {
   // Replace the real GoogleSheetsAPI with our mock
   GoogleSheetsAPI = MockGoogleSheetsAPI;


### PR DESCRIPTION
This commit fixes a bug in the project initialization flow where the `spreadsheetId` was not reliably added to the project object returned after creation.

The `createProject` function in `GoogleSheetsAPI.js` was implicitly relying on the calling function to provide the `spreadsheetId` in the `projectData` argument. This was a fragile dependency.

The fix modifies `createProject` to explicitly add the `spreadsheetId` from the `GoogleSheetsAPI` instance's options to the returned project object. This makes the project creation process more robust and ensures the `spreadsheetId` is always correctly recorded in the project registry.

A new test case, `test_createNewProject`, has been added to `tests/ProjectManager_server.test.js` to verify this fix and prevent future regressions.