### PR TITLE
fix(project): Load hotspots when opening a project

### DIFF
--- a/services/ProjectManager_server.js
+++ b/services/ProjectManager_server.js
@@ -56,6 +56,12 @@ class ProjectManager_server {
     await sheetsAPI.initialize(projectInfo.spreadsheetId);
     const project = await sheetsAPI.getProject(projectId);
     project.slides = await sheetsAPI.getSlidesByProject(projectId);
+
+    // Now, for each slide, get its hotspots
+    for (const slide of project.slides) {
+      slide.hotspots = await sheetsAPI.getHotspotsBySlide(slide.id);
+    }
+
     return project;
   }
   

--- a/tests/ProjectManager_server.test.js
+++ b/tests/ProjectManager_server.test.js
@@ -162,6 +162,13 @@ function test_openProject() {
       success = false;
     }
 
+    if (p.slides[0].hotspots && p.slides[0].hotspots.length === 1 && p.slides[0].hotspots[0].id === 'hotspot_1') {
+      console.log('SUCCESS: Project hotspots are correct.');
+    } else {
+      console.error('FAILURE: Project hotspots are incorrect.');
+      success = false;
+    }
+
     if (success) {
         console.log('TEST PASSED');
     } else {


### PR DESCRIPTION
The `openProject` function was not loading the hotspots associated with each slide. This resulted in a project being opened with incomplete data.

This fix modifies the `openProject` function to iterate through each slide and fetch its hotspots, attaching them to the slide object.

A test case has been added to verify that hotspots are now correctly loaded when a project is opened.